### PR TITLE
added CASCADE to backend comments

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -43,6 +43,6 @@ CREATE TABLE comments (
   my_username TEXT,
   userpost_id INTEGER,
   CONSTRAINT current_username_loggedin FOREIGN KEY (my_username) REFERENCES users(username),
-  CONSTRAINT findspot_id_post FOREIGN KEY (userpost_id) REFERENCES userpost(id)
+  CONSTRAINT findspot_id_post FOREIGN KEY (userpost_id) REFERENCES userpost(id) ON DELETE CASCADE
 );
 


### PR DESCRIPTION
added "ON DELETE CASCADE" to foreign key

CREATE TABLE comments (
  id serial PRIMARY KEY,
  description TEXT,
  date DATE NOT NULL,
  my_username TEXT,
  userpost_id INTEGER,
  CONSTRAINT current_username_loggedin FOREIGN KEY (my_username) REFERENCES users(username),
  CONSTRAINT findspot_id_post FOREIGN KEY (userpost_id) REFERENCES userpost(id) ON DELETE CASCADE
);

