### PR TITLE
Joined comments and userpost tables so data can be accesssed in one fetch in the frontend

### DIFF
--- a/queries/userpost.js
+++ b/queries/userpost.js
@@ -10,8 +10,11 @@ const deleteOne = async (id) => {
   
 };
 
+
+
+
 const getOneuserpost = async (id) =>
-  await db.one("SELECT userpost.id,userpost.full_name, userpost.latitude, userpost.longitude, userpost.description, userpost.skybrightness, userpost.date, userpost.username, userpost.image_url,array_agg(comments.id) AS comments_id,array_agg(comments.description) AS comments_description,array_agg(comments.date) AS comments_date, array_agg(comments.my_username) FROM userpost JOIN comments ON userpost.username=comments.my_username WHERE userpost.id=$1 GROUP BY userpost.id ORDER BY userpost.id", id);
+  await db.one("SELECT userpost.id,userpost.full_name, userpost.latitude, userpost.longitude, userpost.description, userpost.skybrightness, userpost.date, userpost.username, userpost.image_url,array_agg(comments.id) AS comments_id,array_agg(comments.description) AS comments_description,array_agg(comments.date) AS comments_date, array_agg(comments.my_username) FROM userpost JOIN comments ON userpost.id=comments.userpost_id WHERE userpost.id=$1 GROUP BY userpost.id ORDER BY userpost.id", id);
 
   const updateOneuserpost = async (id, userpost) => {
     const postDate = new Date(); 

--- a/queries/userpost.js
+++ b/queries/userpost.js
@@ -10,9 +10,8 @@ const deleteOne = async (id) => {
   
 };
 
-
 const getOneuserpost = async (id) =>
-  await db.one("SELECT * FROM userpost WHERE id=$1", id);
+  await db.one("SELECT userpost.id,userpost.full_name, userpost.latitude, userpost.longitude, userpost.description, userpost.skybrightness, userpost.date, userpost.username, userpost.image_url,array_agg(comments.id) AS comments_id,array_agg(comments.description) AS comments_description,array_agg(comments.date) AS comments_date, array_agg(comments.my_username) FROM userpost JOIN comments ON userpost.username=comments.my_username WHERE userpost.id=$1 GROUP BY userpost.id ORDER BY userpost.id", id);
 
   const updateOneuserpost = async (id, userpost) => {
     const postDate = new Date(); 

--- a/queries/userpost.js
+++ b/queries/userpost.js
@@ -14,7 +14,7 @@ const deleteOne = async (id) => {
 
 
 const getOneuserpost = async (id) =>
-  await db.one("SELECT userpost.id,userpost.full_name, userpost.latitude, userpost.longitude, userpost.description, userpost.skybrightness, userpost.date, userpost.username, userpost.image_url,array_agg(comments.id) AS comments_id,array_agg(comments.description) AS comments_description,array_agg(comments.date) AS comments_date, array_agg(comments.my_username) FROM userpost JOIN comments ON userpost.id=comments.userpost_id WHERE userpost.id=$1 GROUP BY userpost.id ORDER BY userpost.id", id);
+  await db.one("SELECT userpost.id,userpost.full_name, userpost.latitude, userpost.longitude, userpost.description, userpost.skybrightness, userpost.date, userpost.username, userpost.image_url,array_agg(comments.id) AS comments_id,array_agg(comments.description) AS comments_description,array_agg(comments.date) AS comments_date, array_agg(comments.my_username) AS comments_username FROM userpost JOIN comments ON userpost.id=comments.userpost_id WHERE userpost.id=$1 GROUP BY userpost.id ORDER BY userpost.id", id);
 
   const updateOneuserpost = async (id, userpost) => {
     const postDate = new Date(); 


### PR DESCRIPTION
In these commits, I altered the userpost query of getting a single user's post to now include its comments. I joined the comments and userpost tables by the userposts' id and the comments' foreign key to the userpost. Since there can be multiple comments to a single userpost, I made it such that the comments for that userpost is arranged by different arrays holding individual datatypes at their respective index. A single comment will be held at index "1" and another comment's data is found at index "2" from all the comments' arrays, for example.

_Below is mock data from my local database. You can see the comments datafields are spread throughout different arrays, but can be accessed according to its index._

```
{
    "data": {
        "id": 1,
        "full_name": "Meteor Spotted",
        "latitude": "40.691862",
        "longitude": "-73.825071",
        "description": "A meteor fragment lights up the sky in Spain/Portugal!",
        "skybrightness": "Fireball Meteoric Event",
        "date": "2024-05-20T04:00:00.000Z",
        "username": "sharukh.g.velupillai@gmail.com",
        "image_url": "https://res.cloudinary.com/damkrnln2/image/upload/v1716181295/astropics/fxxtunnnqeiczwb0vxez.jpg",
        "comments_id": [
            4,
            8
        ],
        "comments_description": [
            "this is a test",
            "second comment"
        ],
        "comments_date": [
            "2024-05-30T04:00:00.000Z",
            "2024-06-08T04:00:00.000Z"
        ],
        "comments_username": [
            "sharukh.g.velupillai@gmail.com",
            "sharukh.g.velupillai@gmail.com"
        ]
    }
}

```